### PR TITLE
fixes auto hide picker popup

### DIFF
--- a/src/components/ColourPicker.vue
+++ b/src/components/ColourPicker.vue
@@ -123,8 +123,6 @@ export default {
             else {
                 this.colorValue = 'rgba(' + color.rgba.r + ', ' + color.rgba.g + ', ' + color.rgba.b + ', ' + color.rgba.a + ')';
             }
-
-            this.displayPicker = false;
         },
 
         documentClick(e) {


### PR DESCRIPTION
After you click to change the value on the pop-up selection panel, the selection panel will be hidden immediately. In the case where you need to adjust the selected value multiple times (such as dragging to adjust the transparency), this is not a friendly interaction.